### PR TITLE
CAV-327 - Update hmrc libraries to the latest version

### DIFF
--- a/app/uk/gov/hmrc/cipphonenumberfrontend/controllers/OtpController.scala
+++ b/app/uk/gov/hmrc/cipphonenumberfrontend/controllers/OtpController.scala
@@ -38,7 +38,7 @@ class OtpController @Inject()(
   def verifyForm(phoneNumber: Option[String]): Action[AnyContent] = Action.async { implicit request =>
     phoneNumber match {
       case Some(value) => Future.successful(Ok(verifyOtpPage(PhoneNumberAndOtp.form.fill(PhoneNumberAndOtp(value, "")))))
-      case None => Future.successful(SeeOther(routes.LandingPageController.landing().url))
+      case None => Future.successful(SeeOther("/phone-number"))
     }
   }
 

--- a/app/uk/gov/hmrc/cipphonenumberfrontend/controllers/VerifyController.scala
+++ b/app/uk/gov/hmrc/cipphonenumberfrontend/controllers/VerifyController.scala
@@ -55,7 +55,7 @@ class VerifyController @Inject()(
           case Some("Indeterminate") =>
             logger.warn("Non-mobile telephone number used to verify resulted in Indeterminate status")
             BadRequest(verifyPage(PhoneNumber.form.withError("phoneNumber", "verifyPage.mobileonly")))
-          case _ => SeeOther(routes.OtpController.verifyForm(Some(phoneNumber.phoneNumber)).url)
+          case _ => SeeOther(s"/phone-number/verify/otp?phoneNumber=${phoneNumber.phoneNumber}")
         }
         case Left(l) if is4xx(l.statusCode) =>
           logger.warn(l.message)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,16 +4,16 @@ import sbt.Keys.libraryDependencies
 import sbt._
 
 object AppDependencies {
-  val hmrcBootstrapVersion = "5.23.2-RC2"
+  val hmrcBootstrapVersion = "7.2.0"
 
   val compile = Seq(
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % hmrcBootstrapVersion,
-    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "3.14.0-play-28"
+    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "3.19.0-play-28"
   )
 
   val test = Seq(
     "uk.gov.hmrc"            %% "bootstrap-test-play-28"   % hmrcBootstrapVersion % "test, it",
-    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"  % "0.64.0"             % IntegrationTest,
+    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"  % "0.71.0"             % IntegrationTest,
     "org.mockito"            %% "mockito-scala"            % "1.17.7"             % Test
   )
 }

--- a/test/uk/gov/hmrc/cipphonenumberfrontend/controllers/OtpControllerSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberfrontend/controllers/OtpControllerSpec.scala
@@ -132,7 +132,7 @@ class OtpControllerSpec extends AnyWordSpec
   }
 
   trait SetUp {
-    protected val fakeRequest = FakeRequest()
+    protected val fakeRequest = FakeRequest(POST, "")
     protected val mockVerifyOtpPage = mock[VerifyOtpPage]
     protected val mockVerifyConnector = mock[VerifyConnector]
 

--- a/test/uk/gov/hmrc/cipphonenumberfrontend/controllers/VerifyControllerSpec.scala
+++ b/test/uk/gov/hmrc/cipphonenumberfrontend/controllers/VerifyControllerSpec.scala
@@ -121,7 +121,7 @@ class VerifyControllerSpec extends AnyWordSpec
   }
 
   trait SetUp {
-    protected val fakeRequest = FakeRequest()
+    protected val fakeRequest = FakeRequest(POST, "")
     protected val mockVerifyPage = mock[VerifyPage]
     protected val mockVerifyConnector = mock[VerifyConnector]
 


### PR DESCRIPTION
Update HMRC libraries.
Fixed unit tests:
- FakeRequest is a POST (not the default of GET)
- Location header url does not use routes anymore and as a result the unit tests produce the same results and pass in both IntelliJ and the command line