### PR TITLE
CIR-3066 Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,22 +9,32 @@ and prompts the user to enter the code to complete verification.
 ### Unit testing
 To run the unit tests for the application, use the following command:
 
-```sbt test ```
+```bash
+sbt test
+```
 
 
 ### Integration testing
 To run the integration tests, use the following command:
 
-```sbt it/test```
+```bash
+sbt it/test
+```
 
 ### Code coverage
 
-```sbt clean coverage test it/test coverageReport```
+```bash
+sbt clean coverage test it/test coverageReport
+```
 
 ### Running locally
 To run the service locally, you can use the following command:
 
-```./run_local.sh```
+```bash
+./run-local.sh
+```
+
+Once running, access the frontend at http://localhost:6080/phone-number-example-frontend.
 
 ### SBT Updates Plugin
 This project uses the sbt-updates plugin to help manage dependency updates.
@@ -32,9 +42,11 @@ For more information on how to use the plugin, please refer to the documentation
 
 https://github.com/hmrc/platui/blob/main/docs/sbt-updates_plugin-usage.md#sbt-updates-plugin
 
-To check all dependencies (libraries and plugins) the easiest way is to use below command:
+To check all dependencies (libraries and plugins), the easiest way is to use the command below:
 
-```sbt ";dependencyUpdates; reload plugins; dependencyUpdates"```
+```bash
+sbt ";dependencyUpdates; reload plugins; dependencyUpdates"
+```
 
 Keep in mind that the output will be split into two parts where the first one will have libraries and second plugins.
 
@@ -42,9 +54,11 @@ Keep in mind that the output will be split into two parts where the first one wi
 ### Service manager profile
 To run the service using the service manager, use the following command:
 
-```sm2 --start PHONE_NUMBER_ALL```
+```bash
+sm2 --start PHONE_NUMBER_ALL
+```
 
 
 ### License
 
-This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html").
+This code is open source software licensed under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0.html).

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,16 +2,16 @@ import sbt.*
 
 object AppDependencies {
 
-  private val bootstrapPlayVersion = "10.5.0"
+  private val bootstrapPlayVersion = "10.8.0"
   private val playSuffix = "-play-30"
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc" %% s"bootstrap-frontend$playSuffix" % bootstrapPlayVersion,
-    "uk.gov.hmrc" %% s"play-frontend-hmrc$playSuffix" % "12.27.0"
+    "uk.gov.hmrc" %% s"play-frontend-hmrc$playSuffix" % "12.32.1"
   )
 
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% s"bootstrap-test$playSuffix"   % bootstrapPlayVersion,
-    "uk.gov.hmrc.mongo" %% s"hmrc-mongo-test$playSuffix"  % "2.11.0"
+    "uk.gov.hmrc.mongo" %% s"hmrc-mongo-test$playSuffix"  % "2.12.0"
   ).map(_ % Test)
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,8 +10,8 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"        % "sbt-auto-build"      % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"        % "sbt-distributables"  % "2.6.0")
-addSbtPlugin("org.playframework"  % "sbt-plugin"          % "3.0.9")
-addSbtPlugin("org.scoverage"      % "sbt-scoverage"       % "2.4.1")
-addSbtPlugin("org.scalameta"      % "sbt-scalafmt"        % "2.5.6")
+addSbtPlugin("org.playframework"  % "sbt-plugin"          % "3.0.11")
+addSbtPlugin("org.scoverage"      % "sbt-scoverage"       % "2.4.4")
+addSbtPlugin("org.scalameta"      % "sbt-scalafmt"        % "2.6.1")
 addSbtPlugin("com.timushev.sbt"   % "sbt-updates"         % "0.6.4")
 


### PR DESCRIPTION
This pull request updates dependencies and plugins to newer versions and improves the formatting and clarity of the `README.md` instructions. The most important changes are grouped below.

**Dependency and Plugin Updates:**

* Upgraded `bootstrap-frontend` to version `10.8.0` and `play-frontend-hmrc` to `12.32.1` in `AppDependencies.scala`. Also updated test dependencies: `hmrc-mongo-test` to `2.12.0`.
* Updated SBT plugin versions in `plugins.sbt`, including `sbt-plugin` to `3.0.11`, `sbt-scoverage` to `2.4.4`, and `sbt-scalafmt` to `2.6.1`.

**Documentation Improvements:**

* Improved code block formatting in `README.md` by specifying `bash` for code blocks, clarified instructions, updated the local run script name, and fixed the Apache license link.